### PR TITLE
fix implicit declaration warning

### DIFF
--- a/uinputwrapper.c
+++ b/uinputwrapper.c
@@ -58,6 +58,16 @@ int initVKeyboardDevice(char* uinputPath) {
     return deviceHandle;
 }
 
+int syncEvents(int deviceHandle, struct input_event *ev) {
+	memset(ev, 0, sizeof(*ev));
+
+	ev->type  = EV_SYN;
+	ev->code  = 0;
+	ev->value = SYN_REPORT;
+
+	return write(deviceHandle, ev, sizeof(*ev));
+}
+
 int sendBtnEvent(int deviceHandle, int key, int btnState) {
 	// check whether the keycode is valid and return -1 on error
 	if (key < 1 || key > 255) {
@@ -85,16 +95,6 @@ int sendBtnEvent(int deviceHandle, int key, int btnState) {
 	ret = syncEvents(deviceHandle, &ev);
 
 	return ret;
-}
-
-int syncEvents(int deviceHandle, struct input_event *ev) {
-	memset(ev, 0, sizeof(*ev));
-
-	ev->type  = EV_SYN;
-	ev->code  = 0;
-	ev->value = SYN_REPORT;
-
-	return write(deviceHandle, ev, sizeof(*ev));
 }
 
 int releaseDevice(int deviceHandle) {


### PR DESCRIPTION
Fixed warning by moving the declaration of function above it's first usage.

```
./uinputwrapper.c: In function ‘sendBtnEvent’:
./uinputwrapper.c:85:8: warning: implicit declaration of function ‘syncEvents’ [-Wimplicit-function-declaration]
  ret = syncEvents(deviceHandle, &ev);
        ^~~~~~~~~~
```