### PR TITLE
Fix invalid zero value of VKeyboard

### DIFF
--- a/uinput.go
+++ b/uinput.go
@@ -44,7 +44,7 @@ type Keyboard interface {
 
 type vKeyboard struct {
 	name string
-	id   int
+	fd   int
 }
 
 func CreateKeyboard(path, name string) (Keyboard, error) {
@@ -57,17 +57,17 @@ func CreateKeyboard(path, name string) (Keyboard, error) {
 }
 
 func (vk vKeyboard) SendKeyPress(key int) error {
-	return sendBtnEvent(vk.id, key, 1)
+	return sendBtnEvent(vk.fd, key, 1)
 }
 
 func (vk vKeyboard) SendKeyRelease(key int) error {
-	return sendBtnEvent(vk.id, key, 0)
+	return sendBtnEvent(vk.fd, key, 0)
 }
 
 // Close will close the device and free resources.
 // It's usually a good idea to use defer to call this function.
 func (vk vKeyboard) Close() error {
-	return closeDevice(vk.id)
+	return closeDevice(vk.fd)
 }
 
 func createVKeyboardDevice(path, name string) (deviceId int, err error) {

--- a/uinput.go
+++ b/uinput.go
@@ -76,7 +76,14 @@ func (vk *VKeyboard) Close() (err error) {
 	if vk.id < 0 {
 		return errors.New("Keyboard not initialized. Closing device failed.")
 	}
-	return closeDevice(vk.id)
+
+	err = closeDevice(vk.id)
+	if err != nil {
+		return err
+	}
+
+	vk.id = -1
+	return nil
 }
 
 func createVKeyboardDevice(path, name string) (deviceId int, err error) {

--- a/uinput_test.go
+++ b/uinput_test.go
@@ -5,10 +5,8 @@ import (
 )
 
 // This test will create a basic VKeyboard, send a key command and then close the keyboard device
-func TestBasicVKeyboard(t *testing.T) {
-	vk := VKeyboard{}
-	err := vk.Create("/dev/uinput")
-
+func TestBasicKeyboard(t *testing.T) {
+	vk, err := CreateKeyboard("/dev/uinput", "Test Basic Keyboard")
 	if err != nil {
 		t.Fatalf("Failed to create the virtual keyboard. Last error was: %s\n", err)
 	}
@@ -35,9 +33,7 @@ func TestBasicVKeyboard(t *testing.T) {
 // This test will confirm that a proper error code is returned if an invalid uinput path is
 // passed to the library
 func TestInvalidDevicePath(t *testing.T) {
-	vk := VKeyboard{}
-	err := vk.Create("/invalid/path")
-
+	vk, err := CreateKeyboard("/invalid/path", "Invalid Device Path")
 	if err == nil {
 		// this usually shouldn't happen, but if the device is created, we need to close it
 		vk.Close()
@@ -48,15 +44,12 @@ func TestInvalidDevicePath(t *testing.T) {
 // This test will confirm that a proper error code is returned if an invalid keycode is
 // passed to the library
 func TestInvalidKeycode(t *testing.T) {
-	vk := VKeyboard{}
-	err := vk.Create("/dev/uinput")
-
+	vk, err := CreateKeyboard("/dev/uinput", "Test Keyboard")
 	if err != nil {
 		t.Fatalf("Failed to create the virtual keyboard. Last error was: %s\n", err)
 	}
 
 	err = vk.SendKeyPress(4711)
-
 	if err == nil {
 		t.Fatalf("Sending an invalid keycode did not trigger an error. Got: %d.\n")
 	}


### PR DESCRIPTION
I've added an interface that can hide the implementation details of the uinput Keyboard device. With the previous style when creating a VKeyboard{} default value contained id == 0. The SendKey[Press,Release] methods checked for an id < 0 to throw an uninitialized error, but an actual zero value of VKeyboard{} would pass this check producing unexpected/undefined behavior.

To remove the possibility of having an invalid VKeyboard{} value I've hidden it behind an Initialize function(CreateKeyboard) and an interface(Keyboard). The User is now unable to create an invalid instance of VKeyboard.