### PR TITLE
Don't panic within the library, but instead return errors

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -32,8 +32,14 @@ type vKeyboard struct {
 // CreateKeyboard will create a new keyboard using the given uinput
 // device path of the uinput device.
 func CreateKeyboard(path string, name []byte) (Keyboard, error) {
-	validateDevicePath(path)
-	validateUinputName(name)
+	err := validateDevicePath(path)
+	if err != nil {
+		return nil, err
+	}
+	err = validateUinputName(name)
+	if err != nil {
+		return nil, err
+	}
 
 	fd, err := createVKeyboardDevice(path, name)
 	if err != nil {

--- a/keyboard_test.go
+++ b/keyboard_test.go
@@ -2,6 +2,7 @@ package uinput
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -55,46 +56,27 @@ func TestKeysInValidRangeWork(t *testing.T) {
 
 func TestKeyboardCreationFailsOnEmptyPath(t *testing.T) {
 	expected := "device path must not be empty"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateKeyboard("", []byte("KeyboardDevice"))
-	t.Fatalf("Empty path did not yield a panic")
+	_, err := CreateKeyboard("", []byte("KeyboardDevice"))
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestKeyboardCreationFailsOnNonExistentPathName(t *testing.T) {
 	path := "/some/bogus/path"
-	expected := "device path '" + path + "' does not exist"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateKeyboard(path, []byte("KeyboardDevice"))
-	t.Fatalf("Invalid path did not yield a panic")
+	_, err := CreateKeyboard(path, []byte("KeyboardDevice"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("Expected: os.IsNotExist error\nActual: %s", err)
+	}
 }
 
 func TestKeyboardCreationFailsIfNameIsTooLong(t *testing.T) {
 	name := "adsfdsferqewoirueworiuejdsfjdfa;ljoewrjeworiewuoruew;rj;kdlfjoeai;jfewoaifjef;das"
 	expected := fmt.Sprintf("device name %s is too long (maximum of %d characters allowed)", name, uinputMaxNameSize)
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateKeyboard("/dev/uinput", []byte(name))
-	t.Fatalf("Invalid name did not yield a panic")
+	_, err := CreateKeyboard("/dev/uinput", []byte(name))
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestKeyOutsideOfRangeKeyPressFails(t *testing.T) {

--- a/mouse.go
+++ b/mouse.go
@@ -53,8 +53,14 @@ type vMouse struct {
 // CreateMouse will create a new mouse input device. A mouse is a device that allows relative input.
 // Relative input means that all changes to the x and y coordinates of the mouse pointer will be
 func CreateMouse(path string, name []byte) (Mouse, error) {
-	validateDevicePath(path)
-	validateUinputName(name)
+	err := validateDevicePath(path)
+	if err != nil {
+		return nil, err
+	}
+	err = validateUinputName(name)
+	if err != nil {
+		return nil, err
+	}
 
 	fd, err := createMouse(path, name)
 	if err != nil {

--- a/mouse_test.go
+++ b/mouse_test.go
@@ -2,6 +2,7 @@ package uinput
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -70,46 +71,27 @@ func TestBasicMouseMoves(t *testing.T) {
 
 func TestMouseCreationFailsOnEmptyPath(t *testing.T) {
 	expected := "device path must not be empty"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateMouse("", []byte("MouseDevice"))
-	t.Fatalf("Empty path did not yield a panic")
+	_, err := CreateMouse("", []byte("MouseDevice"))
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestMouseCreationFailsOnNonExistentPathName(t *testing.T) {
 	path := "/some/bogus/path"
-	expected := "device path '" + path + "' does not exist"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateMouse(path, []byte("MouseDevice"))
-	t.Fatalf("Invalid path did not yield a panic")
+	_, err := CreateMouse(path, []byte("MouseDevice"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("Expected: os.IsNotExist error\nActual: %s", err)
+	}
 }
 
 func TestMouseCreationFailsIfNameIsTooLong(t *testing.T) {
 	name := "adsfdsferqewoirueworiuejdsfjdfa;ljoewrjeworiewuoruew;rj;kdlfjoeai;jfewoaifjef;das"
 	expected := fmt.Sprintf("device name %s is too long (maximum of %d characters allowed)", name, uinputMaxNameSize)
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	CreateMouse("/dev/uinput", []byte(name))
-	t.Fatalf("Invalid name did not yield a panic")
+	_, err := CreateMouse("/dev/uinput", []byte(name))
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestMouseLeftClickFailsIfDeviceIsClosed(t *testing.T) {

--- a/touchpad.go
+++ b/touchpad.go
@@ -44,8 +44,14 @@ type vTouchPad struct {
 // CreateTouchPad will create a new touch pad device. note that you will need to define the x and y axis boundaries
 // (min and max) within which the cursor maybe moved around.
 func CreateTouchPad(path string, name []byte, minX int32, maxX int32, minY int32, maxY int32) (TouchPad, error) {
-	validateDevicePath(path)
-	validateUinputName(name)
+	err := validateDevicePath(path)
+	if err != nil {
+		return nil, err
+	}
+	err = validateUinputName(name)
+	if err != nil {
+		return nil, err
+	}
 
 	fd, err := createTouchPad(path, name, minX, maxX, minY, maxY)
 	if err != nil {

--- a/touchpad_test.go
+++ b/touchpad_test.go
@@ -2,6 +2,7 @@ package uinput
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -58,46 +59,27 @@ func TestBasicTouchPadMoves(t *testing.T) {
 
 func TestTouchPadCreationFailsOnEmptyPath(t *testing.T) {
 	expected := "device path must not be empty"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	_, _ = CreateTouchPad("", []byte("TouchDevice"), 0, 1024, 0, 768)
-	t.Fatalf("Empty path did not yield a panic")
+	_, err := CreateTouchPad("", []byte("TouchDevice"), 0, 1024, 0, 768)
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestTouchPadCreationFailsOnNonExistentPathName(t *testing.T) {
 	path := "/some/bogus/path"
-	expected := "device path '" + path + "' does not exist"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	_, _ = CreateTouchPad(path, []byte("TouchDevice"), 0, 1024, 0, 768)
-	t.Fatalf("Invalid path did not yield a panic")
+	_, err := CreateTouchPad(path, []byte("TouchDevice"), 0, 1024, 0, 768)
+	if !os.IsNotExist(err) {
+		t.Fatalf("Expected: os.IsNotExist error\nActual: %s", err)
+	}
 }
 
 func TestTouchPadCreationFailsIfNameIsTooLong(t *testing.T) {
 	name := "adsfdsferqewoirueworiuejdsfjdfa;ljoewrjeworiewuoruew;rj;kdlfjoeai;jfewoaifjef;das"
 	expected := fmt.Sprintf("device name %s is too long (maximum of %d characters allowed)", name, uinputMaxNameSize)
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	_, _ = CreateTouchPad("/dev/uinput", []byte(name), 0, 1024, 0, 768)
-	t.Fatalf("Invalid name did not yield a panic")
+	_, err := CreateTouchPad("/dev/uinput", []byte(name), 0, 1024, 0, 768)
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestTouchPadMoveToFailsOnClosedDevice(t *testing.T) {

--- a/uinput.go
+++ b/uinput.go
@@ -86,23 +86,22 @@ import (
 	"time"
 )
 
-func validateDevicePath(path string) {
+func validateDevicePath(path string) error {
 	if path == "" {
-		panic("device path must not be empty")
+		return errors.New("device path must not be empty")
 	}
 	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		panic(fmt.Sprintf("device path '%s' does not exist", path))
-	}
+	return err
 }
 
-func validateUinputName(name []byte) {
+func validateUinputName(name []byte) error {
 	if name == nil || len(name) == 0 {
-		panic(fmt.Sprintf("device name may not be empty"))
+		return errors.New("device name may not be empty")
 	}
 	if len(name) > uinputMaxNameSize {
-		panic(fmt.Sprintf("device name %s is too long (maximum of %d characters allowed)", name, uinputMaxNameSize))
+		return fmt.Errorf("device name %s is too long (maximum of %d characters allowed)", name, uinputMaxNameSize)
 	}
+	return nil
 }
 
 func toUinputName(name []byte) (uinputName [uinputMaxNameSize]byte) {

--- a/uinput_test.go
+++ b/uinput_test.go
@@ -1,46 +1,30 @@
 package uinput
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestValidateDevicePathEmptyPathPanics(t *testing.T) {
 	expected := "device path must not be empty"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	validateDevicePath("")
-	t.Fatalf("Empty path did not yield a panic")
+	err := validateDevicePath("")
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }
 
 func TestValidateDevicePathInvalidPathPanics(t *testing.T) {
 	path := "/some/bogus/path"
-	expected := "device path '" + path + "' does not exist"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	validateDevicePath(path)
-	t.Fatalf("Invalid path did not yield a panic")
+	err := validateDevicePath(path)
+	if !os.IsNotExist(err) {
+		t.Fatalf("Expected: os.IsNotExist error\nActual: %s", err)
+	}
 }
 
 func TestValidateUinputNameEmptyNamePanics(t *testing.T) {
 	expected := "device name may not be empty"
-	defer func() {
-		if r := recover(); r != nil {
-			actual := r.(string)
-			if actual != expected {
-				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
-			}
-		}
-	}()
-	validateUinputName(nil)
-	t.Fatalf("expected panic due to validation error, but nothing happened...")
+	err := validateUinputName(nil)
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nActual: %s", expected, err)
+	}
 }


### PR DESCRIPTION
This lets users of the package decide whether they want to handle the error gracefully instead of panicking.