### PR TITLE
Increase keyMax to max value as defined by evdev

### DIFF
--- a/keycodes.go
+++ b/keycodes.go
@@ -244,7 +244,7 @@ const (
 	KeyBrightnessZero   = 244 /*BrightnessOff,UseAmbient*/
 	KeyDisplayOff       = 245 /*DisplayDeviceToOffState*/
 	KeyWimax            = 246
-	KeyRfkill           = 247 /*KeyThatControlsAllRadios*/
-	KeyMicmute          = 248 /*Mute/UnmuteTheMicrophone*/
-	keyMax              = 248 // highest key currently defined
+	KeyRfkill           = 247   /*KeyThatControlsAllRadios*/
+	KeyMicmute          = 248   /*Mute/UnmuteTheMicrophone*/
+	keyMax              = 0x2ff // highest key currently defined
 )


### PR DESCRIPTION
Increase keyMax to the maximum as defined by evdev. This makes sure we don't exclude "multimedia" and other functional keycodes.