### PR TITLE
attach the SYN_REPORT in the code during sync EVs

### DIFF
--- a/uinput.go
+++ b/uinput.go
@@ -192,8 +192,8 @@ func syncEvents(deviceFile *os.File) (err error) {
 	buf, err := inputEventToBuffer(inputEvent{
 		Time:  syscall.Timeval{Sec: 0, Usec: 0},
 		Type:  evSyn,
-		Code:  0,
-		Value: int32(synReport)})
+		Code:  uint16(synReport),
+		Value: 0})
 	if err != nil {
 		return fmt.Errorf("writing sync event failed: %v", err)
 	}


### PR DESCRIPTION
It seems from reading the [uinput examples on kernal.org](https://www.kernel.org/doc/html/latest/input/uinput.html#examples) that the SYN_REPORT should be sent in the code field and not the value. It doesn't have much effect, give that they're both `0`.

Please let me know if I've misunderstood!