### PR TITLE
Added ioctl UI_DEV_SETUP call before UI_DEV_CREATE

### DIFF
--- a/uinput.go
+++ b/uinput.go
@@ -139,7 +139,7 @@ func createUsbDevice(deviceFile *os.File, dev uinputUserDev) (fd *os.File, err e
 		_ = deviceFile.Close()
 		return nil, fmt.Errorf("failed to write user device buffer: %v", err)
 	}
-	_, err = deviceFile.Write(buf.Bytes())
+	err = ioctl(deviceFile, uiDevSetup, uintptr(unsafe.Pointer(buf)))
 	if err != nil {
 		_ = deviceFile.Close()
 		return nil, fmt.Errorf("failed to write uidev struct to device file: %v", err)

--- a/uinputdefs.go
+++ b/uinputdefs.go
@@ -7,6 +7,7 @@ const (
 	uinputMaxNameSize = 80
 	uiDevCreate       = 0x5501
 	uiDevDestroy      = 0x5502
+	uiDevSetup        = 0x405c5503
 	// this is for 64 length buffer to store name
 	// for another length generate using : (len << 16) | 0x8000552C
 	uiGetSysname = 0x8041552c


### PR DESCRIPTION
The current implementation using fwrite() was causing new device events not to be properly identified on Wayland (Sway), rendering the udevice useless.

This change moves the code closer to the reference kernel impl from https://kernel.org/doc/html/v6.2/input/uinput.html